### PR TITLE
Use emoji SVG favicon and prevent ICO override

### DIFF
--- a/frontend/src/app/icon.svg
+++ b/frontend/src/app/icon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="100" height="100" fill="transparent"/>
+  <text x="50" y="62" text-anchor="middle" font-size="84" font-family="Apple Color Emoji, Segoe UI Emoji, Noto Color Emoji, Twemoji, sans-serif">🉐</text>
+</svg>
+
+

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -9,7 +9,7 @@ export const metadata: Metadata = {
   title: "Chinese Flashcards",
   description: "Practice Chinese characters with interactive flashcards",
   icons: {
-    icon: "data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🉐</text></svg>",
+    icon: "/icon.svg",
   },
 };
 


### PR DESCRIPTION
Replace the inline data URL favicon with a dedicated /icon.svg emoji favicon and remove the default favicon.ico so the app's favicon actually updates. This ensures Next.js metadata icons reference the new /icon.svg and prevents the old favicon.ico from overriding it.

• Added frontend/src/app/icon.svg containing the emoji favicon
• Updated frontend/src/app/layout.tsx to point icons.icon to /icon.svg instead of the data URI
• Removed the default frontend/src/app/favicon.ico (preventing it from overriding the new SVG)
• (Other unrelated CI and lint/type-check additions included in the diff)