### PR TITLE
fix: first fetch unknown characters

### DIFF
--- a/frontend/src/app/api/_lib/domain/notionFilter.ts
+++ b/frontend/src/app/api/_lib/domain/notionFilter.ts
@@ -21,34 +21,6 @@ export const notKnownCharactersFilter = ({
           {
             property: propertiesMappingFromDomainToNotion.lastSeenAt,
             date: {
-              before: dayjs().subtract(1, "month").format("YYYY-MM-DD"),
-            },
-          },
-          {
-            property: propertiesMappingFromDomainToNotion.levelOfConfidence,
-            status: {
-              equals: "✅",
-            },
-          },
-          characterImportance && {
-            property: propertiesMappingFromDomainToNotion.importance,
-            select: {
-              equals: importanceMappingFromDomainToNotion[characterImportance],
-            },
-          },
-          characterType && {
-            property: propertiesMappingFromDomainToNotion.type,
-            multi_select: {
-              contains: typesMappingFromDomainToNotion[characterType],
-            },
-          },
-        ]),
-      },
-      {
-        and: compact([
-          {
-            property: propertiesMappingFromDomainToNotion.lastSeenAt,
-            date: {
               before: dayjs().subtract(3, "day").format("YYYY-MM-DD"),
             },
           },
@@ -75,7 +47,53 @@ export const notKnownCharactersFilter = ({
     ],
   };
 
-  console.log("Filter", filter);
+  console.log("Not known characters filter", filter);
+
+  return filter;
+};
+
+
+export const recentlyKnownCharactersFilter = ({
+  characterType,
+  characterImportance,
+}: {
+  characterType: CharacterType | null;
+  characterImportance: CharacterImportance | null;
+}) => {
+  const filter = {
+    or: [
+      {
+        and: compact([
+          {
+            property: propertiesMappingFromDomainToNotion.lastSeenAt,
+            date: {
+              before: dayjs().subtract(1, "month").format("YYYY-MM-DD"),
+            },
+          },
+          {
+            property: propertiesMappingFromDomainToNotion.levelOfConfidence,
+            status: {
+              equals: "✅",
+            },
+          },
+          characterImportance && {
+            property: propertiesMappingFromDomainToNotion.importance,
+            select: {
+              equals: importanceMappingFromDomainToNotion[characterImportance],
+            },
+          },
+          characterType && {
+            property: propertiesMappingFromDomainToNotion.type,
+            multi_select: {
+              contains: typesMappingFromDomainToNotion[characterType],
+            },
+          },
+        ]),
+      },
+    ],
+  };
+
+  console.log("Recently known characters filter", filter);
 
   return filter;
 };

--- a/frontend/src/app/api/fetch-chinese-character/route.ts
+++ b/frontend/src/app/api/fetch-chinese-character/route.ts
@@ -4,6 +4,7 @@ import {
   notKnownCharactersFilter,
   characterNeedsRefresh,
   selectRandomCharacter,
+  recentlyKnownCharactersFilter,
 } from "../_lib/domain/notionFilter";
 import { CharacterType, CharacterImportance } from "../_lib/domain/types";
 
@@ -15,7 +16,7 @@ export async function POST(request: Request) {
       characterType: CharacterType | null;
       characterImportance: CharacterImportance | null;
     };
-    const eligibleCharacters = await fetchChineseCharactersFromDatabase(
+    const unknownCharacters = await fetchChineseCharactersFromDatabase(
       notKnownCharactersFilter({
         characterType,
         characterImportance,
@@ -23,7 +24,21 @@ export async function POST(request: Request) {
       50
     );
 
-    const charactersNeedingRefresh = eligibleCharacters.filter(
+    if (unknownCharacters.length > 0) {
+      const selectedCharacter = selectRandomCharacter(unknownCharacters);
+      return NextResponse.json(selectedCharacter ?? null, { status: 200 });
+    }
+    
+    
+    const recentlyKnownCharacters = await fetchChineseCharactersFromDatabase(
+      recentlyKnownCharactersFilter({
+        characterType,
+        characterImportance,
+      }),
+      50
+    );
+
+    const charactersNeedingRefresh = recentlyKnownCharacters.filter(
       characterNeedsRefresh
     );
 


### PR DESCRIPTION
the problem was that notion api favored the known characters and most of them didn’t need any refresh (due to the 50 limitation). 

Now I first fetch the characters which are NOT known.