### PR TITLE
feat: Add Supabase login flow with persistent client sessions

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,5 +1,10 @@
+# Auth (required for login; use Publishable key or legacy anon key)
+NEXT_PUBLIC_SUPABASE_URL=https://YOUR_PROJECT_REF.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your_anon_or_publishable_key
+
+# API routes and server-side (use Secret key or legacy service_role key)
 SUPABASE_URL=https://YOUR_PROJECT_REF.supabase.co
-SUPABASE_SERVICE_ROLE_KEY=YOUR_SERVICE_ROLE_KEY
+SUPABASE_SERVICE_ROLE_KEY=YOUR_SERVICE_ROLE_OR_SECRET_KEY
 
 # Optional: one-time migration script only
 NOTION_API_KEY=

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -34,3 +34,14 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details.
+
+## Supabase auth setup
+
+Add these environment variables to `frontend/.env.local`:
+
+```bash
+NEXT_PUBLIC_SUPABASE_URL=your_supabase_project_url
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key
+```
+
+The app now requires login before loading flashcards, and persists the Supabase auth session in local storage so you don't need to login every time.

--- a/frontend/globals.d.ts
+++ b/frontend/globals.d.ts
@@ -5,6 +5,8 @@ declare global {
       NOTION_API_KEY?: string;
       NOTION_DATABASE_ID?: string;
       NOTION_VOCABULARY_DATASOURCE_ID?: string;
+      NEXT_PUBLIC_SUPABASE_URL?: string;
+      NEXT_PUBLIC_SUPABASE_ANON_KEY?: string;
       SUPABASE_URL: string;
       SUPABASE_SERVICE_ROLE_KEY: string;
     }

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -19,8 +19,8 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
-      <body className={inter.className}>
+    <html lang="en" className="dark">
+      <body className={`${inter.className} min-h-screen bg-background text-foreground`}>
         {children}
         <Toaster richColors />
       </body>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,18 +1,74 @@
 "use client";
+
 import "@radix-ui/themes/styles.css";
 import { Theme } from "@radix-ui/themes";
+import { useCallback, useEffect, useState } from "react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { FlashcardsContainer } from "../components/FlashcardsContainer";
+import { LoginPage } from "../components/LoginPage";
+import {
+  type AuthenticatedUser,
+  getCurrentUser,
+  getStoredSession,
+  hydrateSessionFromUrl,
+  refreshSession,
+  signOut,
+} from "../lib/supabaseClient";
+
 const queryClient = new QueryClient();
 
 export default function Home() {
+  const [isLoadingSession, setIsLoadingSession] = useState(true);
+  const [authenticatedUser, setAuthenticatedUser] = useState<AuthenticatedUser | null>(null);
+
+  const loadCurrentUser = useCallback(async () => {
+    try {
+      hydrateSessionFromUrl();
+
+      const session = getStoredSession();
+      if (!session) {
+        setAuthenticatedUser(null);
+        return;
+      }
+
+      const expiresAt = session.expires_at ?? 0;
+      const hasExpired = expiresAt > 0 && Date.now() > expiresAt - 30_000;
+      const activeSession = hasExpired ? await refreshSession(session.refresh_token) : session;
+
+      const user = await getCurrentUser(activeSession.access_token);
+      setAuthenticatedUser(user);
+    } catch {
+      setAuthenticatedUser(null);
+    } finally {
+      setIsLoadingSession(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadCurrentUser();
+  }, [loadCurrentUser]);
+
+  const onLogout = async () => {
+    await signOut();
+    setAuthenticatedUser(null);
+  };
+
   return (
-    <main className="flex min-h-screen flex-col justify-between">
-      <QueryClientProvider client={queryClient}>
-        <Theme>
-          <FlashcardsContainer />
-        </Theme>
-      </QueryClientProvider>
+    <main className="flex min-h-screen flex-col bg-background">
+      <Theme>
+        {isLoadingSession ? (
+          <div className="flex min-h-screen items-center justify-center text-sm text-muted-foreground">Loading session...</div>
+        ) : authenticatedUser ? (
+          <QueryClientProvider client={queryClient}>
+            <FlashcardsContainer
+              onLogout={onLogout}
+              userEmail={authenticatedUser.email ?? undefined}
+            />
+          </QueryClientProvider>
+        ) : (
+          <LoginPage onLoggedIn={loadCurrentUser} />
+        )}
+      </Theme>
     </main>
   );
 }

--- a/frontend/src/components/FlashcardsContainer.tsx
+++ b/frontend/src/components/FlashcardsContainer.tsx
@@ -22,7 +22,12 @@ import { useOnConfigurationChange } from "./hooks/useOnConfgiurationChange";
 import { SessionCharacterLists } from "./session-character-lists";
 import { ChineseCharacter } from "./types";
 
-export function FlashcardsContainer() {
+type FlashcardsContainerProps = {
+  onLogout?: () => void;
+  userEmail?: string;
+};
+
+export function FlashcardsContainer({ onLogout, userEmail }: FlashcardsContainerProps = {}) {
   const {
     showIdeogram,
     setShowIdeogram,
@@ -217,11 +222,27 @@ export function FlashcardsContainer() {
     isCreateCharacterLoading || isUpdateCharacterLoading;
 
   return (
-    <div className="dark flex flex-col items-center justify-center h-screen bg-background text-card-foreground relative overflow-hidden">
+    <div className="dark flex flex-col items-center justify-center min-h-screen w-full bg-background text-card-foreground relative overflow-hidden">
       <div className="absolute inset-0 bg-linear-to-br from-blue-950/30 via-background to-indigo-950/20 pointer-events-none" />
-      <div className="absolute top-4 right-4 z-10 glass rounded-xl px-4 py-2 text-sm font-medium text-muted-foreground shadow-lg">
-        <span className="text-foreground font-semibold">{uniqueSeenCount}</span>{" "}
-        seen
+      <div className="absolute top-4 left-4 z-10 flex items-center gap-3">
+        {onLogout ? (
+          <button
+            className="glass rounded-xl px-4 py-2 text-sm font-medium text-muted-foreground transition hover:text-foreground"
+            onClick={onLogout}
+            type="button"
+          >
+            🚪 Sign out
+          </button>
+        ) : null}
+      </div>
+      <div className="absolute top-4 right-4 z-10 flex items-center gap-3">
+        {userEmail ? (
+          <span className="glass rounded-xl px-4 py-2 text-sm text-muted-foreground">{userEmail}</span>
+        ) : null}
+        <div className="glass rounded-xl px-4 py-2 text-sm font-medium text-muted-foreground shadow-lg">
+          <span className="text-foreground font-semibold">{uniqueSeenCount}</span>{" "}
+          seen
+        </div>
       </div>
       <div className="relative flex w-full max-w-7xl gap-6 px-6">
         <FiltersPanel

--- a/frontend/src/components/LoginPage.tsx
+++ b/frontend/src/components/LoginPage.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { FormEvent, useState } from "react";
+import { signInWithPassword, startGoogleOAuthLogin } from "../lib/supabaseClient";
+
+type LoginPageProps = {
+  onLoggedIn: () => Promise<void>;
+};
+
+export const LoginPage = ({ onLoggedIn }: LoginPageProps) => {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const onPasswordLogin = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setErrorMessage(null);
+    setIsSubmitting(true);
+
+    try {
+      await signInWithPassword(email.trim(), password);
+      await onLoggedIn();
+    } catch (error) {
+      setErrorMessage(error instanceof Error ? error.message : "Login failed");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const onGoogleLogin = () => {
+    setErrorMessage(null);
+    setIsSubmitting(true);
+    startGoogleOAuthLogin();
+  };
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-background p-4">
+      <div className="absolute inset-0 bg-[linear-gradient(to_bottom_right,hsl(230_25%_7%),hsl(230_30%_12%))] pointer-events-none" />
+      <div className="relative w-full max-w-md rounded-2xl border border-white/10 bg-card p-6 shadow-xl shadow-cyan-950/20">
+        <h1 className="text-2xl font-semibold tracking-tight text-foreground">Sign in</h1>
+        <p className="mt-1 text-sm text-muted-foreground">Use your email/password or Google account.</p>
+
+        <form className="mt-6 space-y-4" onSubmit={onPasswordLogin}>
+          <div className="space-y-1">
+            <label className="text-sm font-medium text-foreground" htmlFor="email">
+              Email
+            </label>
+            <input
+              id="email"
+              className="w-full rounded-lg border border-white/10 bg-white/5 px-3 py-2 text-sm text-foreground outline-none placeholder:text-muted-foreground focus:border-cyan-400/50 focus:ring-2 focus:ring-cyan-400/20"
+              type="email"
+              value={email}
+              onChange={(event) => setEmail(event.target.value)}
+              autoComplete="email"
+              required
+            />
+          </div>
+
+          <div className="space-y-1">
+            <label className="text-sm font-medium text-foreground" htmlFor="password">
+              Password
+            </label>
+            <input
+              id="password"
+              className="w-full rounded-lg border border-white/10 bg-white/5 px-3 py-2 text-sm text-foreground outline-none placeholder:text-muted-foreground focus:border-cyan-400/50 focus:ring-2 focus:ring-cyan-400/20"
+              type="password"
+              value={password}
+              onChange={(event) => setPassword(event.target.value)}
+              autoComplete="current-password"
+              required
+            />
+          </div>
+
+          {errorMessage ? <p className="text-sm text-red-400">{errorMessage}</p> : null}
+
+          <button
+            className="w-full rounded-xl bg-emerald-600 px-4 py-2.5 text-sm font-medium text-white shadow-lg shadow-emerald-900/30 transition hover:bg-emerald-500 disabled:cursor-not-allowed disabled:opacity-60"
+            type="submit"
+            disabled={isSubmitting}
+          >
+            {isSubmitting ? "Signing in..." : "Sign in with email"}
+          </button>
+        </form>
+
+        <div className="my-4 flex items-center gap-3 text-xs text-muted-foreground">
+          <div className="h-px flex-1 bg-white/10" />
+          <span>OR</span>
+          <div className="h-px flex-1 bg-white/10" />
+        </div>
+
+        <button
+          className="w-full rounded-xl border border-white/10 bg-white/5 px-4 py-2.5 text-sm font-medium text-foreground transition hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-60"
+          type="button"
+          onClick={onGoogleLogin}
+          disabled={isSubmitting}
+        >
+          Continue with Google
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/lib/supabaseClient.ts
+++ b/frontend/src/lib/supabaseClient.ts
@@ -1,0 +1,156 @@
+export type AuthenticatedUser = {
+  id: string;
+  email?: string;
+};
+
+type AuthSession = {
+  access_token: string;
+  refresh_token: string;
+  expires_at?: number;
+};
+
+const STORAGE_KEY = "supabase.auth.session";
+
+const getSupabaseCredentials = () => {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+  if (!url || !anonKey) {
+    throw new Error(
+      "Missing NEXT_PUBLIC_SUPABASE_URL or NEXT_PUBLIC_SUPABASE_ANON_KEY environment variable"
+    );
+  }
+
+  return { url, anonKey };
+};
+
+const getHeaders = () => {
+  const { anonKey } = getSupabaseCredentials();
+  return {
+    apikey: anonKey,
+    "Content-Type": "application/json",
+  };
+};
+
+export const getStoredSession = (): AuthSession | null => {
+  const raw = window.localStorage.getItem(STORAGE_KEY);
+  if (!raw) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(raw) as AuthSession;
+  } catch {
+    return null;
+  }
+};
+
+export const storeSession = (session: AuthSession) => {
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(session));
+};
+
+export const clearSession = () => {
+  window.localStorage.removeItem(STORAGE_KEY);
+};
+
+export const signInWithPassword = async (email: string, password: string) => {
+  const { url } = getSupabaseCredentials();
+  const response = await fetch(`${url}/auth/v1/token?grant_type=password`, {
+    method: "POST",
+    headers: getHeaders(),
+    body: JSON.stringify({ email, password }),
+  });
+
+  if (!response.ok) {
+    const message = await response.text();
+    throw new Error(message || "Login failed");
+  }
+
+  const data = (await response.json()) as AuthSession;
+  storeSession(data);
+  return data;
+};
+
+export const startGoogleOAuthLogin = () => {
+  const { url, anonKey } = getSupabaseCredentials();
+  const redirectTo = encodeURIComponent(window.location.origin);
+  window.location.href = `${url}/auth/v1/authorize?provider=google&redirect_to=${redirectTo}&apikey=${anonKey}`;
+};
+
+export const hydrateSessionFromUrl = () => {
+  const hash = window.location.hash.replace(/^#/, "");
+  if (!hash) {
+    return false;
+  }
+
+  const params = new URLSearchParams(hash);
+  const accessToken = params.get("access_token");
+  const refreshToken = params.get("refresh_token");
+  const expiresIn = params.get("expires_in");
+
+  if (!accessToken || !refreshToken) {
+    return false;
+  }
+
+  storeSession({
+    access_token: accessToken,
+    refresh_token: refreshToken,
+    expires_at: expiresIn ? Date.now() + Number(expiresIn) * 1000 : undefined,
+  });
+
+  window.history.replaceState({}, document.title, window.location.pathname);
+  return true;
+};
+
+export const refreshSession = async (refreshToken: string) => {
+  const { url } = getSupabaseCredentials();
+  const response = await fetch(`${url}/auth/v1/token?grant_type=refresh_token`, {
+    method: "POST",
+    headers: getHeaders(),
+    body: JSON.stringify({ refresh_token: refreshToken }),
+  });
+
+  if (!response.ok) {
+    throw new Error("Unable to refresh session");
+  }
+
+  const data = (await response.json()) as AuthSession;
+  storeSession(data);
+  return data;
+};
+
+export const getCurrentUser = async (accessToken: string) => {
+  const { url, anonKey } = getSupabaseCredentials();
+  const response = await fetch(`${url}/auth/v1/user`, {
+    headers: {
+      apikey: anonKey,
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error("Unable to fetch current user");
+  }
+
+  return (await response.json()) as AuthenticatedUser;
+};
+
+export const signOut = async () => {
+  const session = getStoredSession();
+  if (!session) {
+    clearSession();
+    return;
+  }
+
+  const { url, anonKey } = getSupabaseCredentials();
+  await fetch(`${url}/auth/v1/logout`, {
+    method: "POST",
+    headers: {
+      apikey: anonKey,
+      Authorization: `Bearer ${session.access_token}`,
+      "Content-Type": "application/json",
+    },
+  });
+
+  clearSession();
+};


### PR DESCRIPTION
### Motivation
- Require users to authenticate before using the flashcards and keep them signed in between visits by persisting Supabase sessions client-side.
- Provide both email/password and a simple Google OAuth sign-in option so users can choose the easiest method.
- Avoid adding the heavier `@supabase/supabase-js` dependency in this change by using minimal REST-based auth helpers to keep the implementation lightweight.

### Description
- Add a gated home page in `frontend/src/app/page.tsx` that loads the current session, shows a `LoginPage` when unauthenticated, and displays a sign-out button when signed in.
- Implement a new `LoginPage` UI at `frontend/src/components/LoginPage.tsx` with email/password form handling and a Google sign-in button that starts an OAuth redirect.
- Add lightweight Supabase Auth helpers in `frontend/src/lib/supabaseClient.ts` that handle password sign-in, OAuth redirect, URL-hash session hydration, localStorage session persistence, token refresh, current-user fetch, and logout.
- Document required public Supabase environment variables in `frontend/README.md` and instruct adding `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY` to `frontend/.env.local`.

### Testing
- Ran TypeScript checks with `cd frontend && pnpm type-check`, which completed successfully.
- Ran test suite with `cd frontend && pnpm test` and all existing tests passed (`vitest` tests passed).
- Started the dev server with example env vars and captured a UI screenshot to validate the login page, the server ran and the page compiled, though Next.js reported a Google Fonts fetch failure in this environment and fell back to a local font.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af377b24f4832f9726dc93f95a6661)