### PR TITLE
Add Vitest setup and unit tests for character APIs and selection logic

### DIFF
--- a/frontend/src/app/api/_lib/domain/__tests__/selectRandomCharacter.test.ts
+++ b/frontend/src/app/api/_lib/domain/__tests__/selectRandomCharacter.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { selectRandomCharacter } from "../characterSelection";
+import { ChineseCharacter } from "../types";
+
+const characters: ChineseCharacter[] = [
+  {
+    id: "1",
+    character: "你",
+    translation: "you",
+    example: null,
+    addedAt: null,
+    type: "noun",
+    importance: "high",
+    lastSeenAt: null,
+    numberOfCorrectAnswers: 0,
+    levelOfConfidence: "low",
+  },
+  {
+    id: "2",
+    character: "好",
+    translation: "good",
+    example: null,
+    addedAt: null,
+    type: "adjective",
+    importance: "high",
+    lastSeenAt: null,
+    numberOfCorrectAnswers: 2,
+    levelOfConfidence: "high",
+  },
+];
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("selectRandomCharacter", () => {
+  it("returns the first character when random is 0", () => {
+    vi.spyOn(Math, "random").mockReturnValue(0);
+
+    const selected = selectRandomCharacter(characters);
+
+    expect(selected).toEqual(characters[0]);
+  });
+
+  it("returns the last character when random is close to 1", () => {
+    vi.spyOn(Math, "random").mockReturnValue(0.99999);
+
+    const selected = selectRandomCharacter(characters);
+
+    expect(selected).toEqual(characters[1]);
+  });
+});

--- a/frontend/src/app/api/character-known/__tests__/route.test.ts
+++ b/frontend/src/app/api/character-known/__tests__/route.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { POST } from "../route";
+import { setCharacterKnown } from "../../_lib/dependencies/supabase";
+
+vi.mock("../../_lib/dependencies/supabase", () => ({
+  setCharacterKnown: vi.fn(),
+}));
+
+const setCharacterKnownMock = vi.mocked(setCharacterKnown);
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("POST /api/character-known", () => {
+  it("returns 400 when id is missing", async () => {
+    const request = new Request("http://localhost/api/character-known", {
+      method: "POST",
+      body: JSON.stringify({}),
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: "Missing id" });
+    expect(setCharacterKnownMock).not.toHaveBeenCalled();
+  });
+
+  it("marks character as known when id is provided", async () => {
+    const request = new Request("http://localhost/api/character-known", {
+      method: "POST",
+      body: JSON.stringify({ id: "abc" }),
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ id: "abc" });
+    expect(setCharacterKnownMock).toHaveBeenCalledWith("abc");
+  });
+
+  it("returns 500 when update fails", async () => {
+    setCharacterKnownMock.mockRejectedValueOnce(new Error("db down"));
+
+    const request = new Request("http://localhost/api/character-known", {
+      method: "POST",
+      body: JSON.stringify({ id: "abc" }),
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual({ error: "Failed to update character" });
+  });
+});

--- a/frontend/src/app/api/character-unknown/__tests__/route.test.ts
+++ b/frontend/src/app/api/character-unknown/__tests__/route.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { POST } from "../route";
+import { setCharacterUnknown } from "../../_lib/dependencies/supabase";
+
+vi.mock("../../_lib/dependencies/supabase", () => ({
+  setCharacterUnknown: vi.fn(),
+}));
+
+const setCharacterUnknownMock = vi.mocked(setCharacterUnknown);
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("POST /api/character-unknown", () => {
+  it("returns 400 when id is missing", async () => {
+    const request = new Request("http://localhost/api/character-unknown", {
+      method: "POST",
+      body: JSON.stringify({}),
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: "Missing id" });
+    expect(setCharacterUnknownMock).not.toHaveBeenCalled();
+  });
+
+  it("marks character as unknown when id is provided", async () => {
+    const request = new Request("http://localhost/api/character-unknown", {
+      method: "POST",
+      body: JSON.stringify({ id: "abc" }),
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ id: "abc" });
+    expect(setCharacterUnknownMock).toHaveBeenCalledWith("abc");
+  });
+
+  it("returns 500 when update fails", async () => {
+    setCharacterUnknownMock.mockRejectedValueOnce(new Error("db down"));
+
+    const request = new Request("http://localhost/api/character-unknown", {
+      method: "POST",
+      body: JSON.stringify({ id: "abc" }),
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual({ error: "Failed to update character" });
+  });
+});

--- a/frontend/src/app/api/fetch-chinese-character/__tests__/route.test.ts
+++ b/frontend/src/app/api/fetch-chinese-character/__tests__/route.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { POST } from "../route";
+import type { ChineseCharacter } from "../../_lib/domain/types";
+import {
+  fetchRecentlyKnownCharacters,
+  fetchUnknownCharacters,
+} from "../../_lib/dependencies/supabase";
+
+vi.mock("../../_lib/dependencies/supabase", () => ({
+  fetchUnknownCharacters: vi.fn(),
+  fetchRecentlyKnownCharacters: vi.fn(),
+}));
+
+const fetchUnknownCharactersMock = vi.mocked(fetchUnknownCharacters);
+const fetchRecentlyKnownCharactersMock = vi.mocked(fetchRecentlyKnownCharacters);
+
+const createCharacter = (
+  id: string,
+  levelOfConfidence: "high" | "low",
+  numberOfCorrectAnswers: number,
+  lastSeenAt: Date
+): ChineseCharacter => ({
+  id,
+  character: "字",
+  translation: "character",
+  example: null,
+  addedAt: null,
+  type: "noun",
+  importance: "high",
+  levelOfConfidence,
+  numberOfCorrectAnswers,
+  lastSeenAt,
+});
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2026-03-01T00:00:00.000Z"));
+  vi.spyOn(Math, "random").mockReturnValue(0);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe("POST /api/fetch-chinese-character", () => {
+  it("returns one of the unknown characters when available", async () => {
+    const unknown = [createCharacter("unknown-1", "low", 0, new Date())];
+    fetchUnknownCharactersMock.mockResolvedValueOnce(unknown);
+
+    const request = new Request("http://localhost/api/fetch-chinese-character", {
+      method: "POST",
+      body: JSON.stringify({ characterType: "noun", characterImportance: "high" }),
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      ...unknown[0],
+      lastSeenAt: unknown[0].lastSeenAt?.toISOString() ?? null,
+    });
+    expect(fetchUnknownCharactersMock).toHaveBeenCalledWith(
+      { characterType: "noun", characterImportance: "high" },
+      50
+    );
+    expect(fetchRecentlyKnownCharactersMock).not.toHaveBeenCalled();
+  });
+
+  it("falls back to recently known characters and filters forgotten characters", async () => {
+    fetchUnknownCharactersMock.mockResolvedValueOnce([]);
+    const forgotten = createCharacter(
+      "known-1",
+      "high",
+      1,
+      new Date("2026-01-01T00:00:00.000Z")
+    );
+    const fresh = createCharacter(
+      "known-2",
+      "high",
+      5,
+      new Date("2026-02-28T00:00:00.000Z")
+    );
+
+    fetchRecentlyKnownCharactersMock.mockResolvedValueOnce([forgotten, fresh]);
+
+    const request = new Request("http://localhost/api/fetch-chinese-character", {
+      method: "POST",
+      body: JSON.stringify({ characterType: null, characterImportance: null }),
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      ...forgotten,
+      lastSeenAt: forgotten.lastSeenAt?.toISOString() ?? null,
+    });
+    expect(fetchRecentlyKnownCharactersMock).toHaveBeenCalledWith(
+      { characterType: null, characterImportance: null },
+      50
+    );
+  });
+
+  it("returns 500 when data fetching fails", async () => {
+    fetchUnknownCharactersMock.mockRejectedValueOnce(new Error("db down"));
+
+    const request = new Request("http://localhost/api/fetch-chinese-character", {
+      method: "POST",
+      body: JSON.stringify({ characterType: null, characterImportance: null }),
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual({ error: "Failed to fetch character" });
+  });
+});

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
   test: {
     environment: "node",
     globals: true,
+    setupFiles: ["./vitest.setup.ts"],
   },
   resolve: {
     alias: {

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -1,0 +1,16 @@
+import { afterEach, vi } from "vitest";
+
+// Prevent accidental outbound network calls in unit/integration tests.
+// Tests that intentionally need fetch should mock it explicitly.
+vi.stubGlobal(
+  "fetch",
+  vi.fn(async () => {
+    throw new Error(
+      "Unexpected network call in test. Mock auth/dependencies instead of calling real services."
+    );
+  })
+);
+
+afterEach(() => {
+  vi.clearAllMocks();
+});


### PR DESCRIPTION
### Motivation

- Add unit tests to cover character selection and API routes for marking characters known/unknown and fetching characters to increase confidence in behavior. 
- Prevent accidental external network calls from unit tests by stubbing `fetch` globally.

### Description

- Add tests for `selectRandomCharacter` in `frontend/src/app/api/_lib/domain/__tests__/selectRandomCharacter.test.ts` which mock `Math.random` for deterministic selection. 
- Add API route tests for `POST /api/character-known`, `POST /api/character-unknown`, and `POST /api/fetch-chinese-character` in their respective `__tests__` folders, mocking Supabase dependency functions and using fake timers where necessary. 
- Introduce `frontend/vitest.setup.ts` to stub global `fetch` and clear mocks after each test, and update `frontend/vitest.config.ts` to include the setup file via `setupFiles`.

### Testing

- No automated tests were executed as part of this rollout. 
- The new tests are written for Vitest and use module mocks (`vi.mock`), `vi.useFakeTimers`, and global `fetch` stubbing so they can be run locally or in CI with `vitest`/`pnpm vitest` to verify behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af376f4378832fbd88a59fe8b1e5ca)