### PR TITLE
Introduce layout primitives and migrate major app UI to design-system components

### DIFF
--- a/frontend/src/components/CharacterEditorModal.tsx
+++ b/frontend/src/components/CharacterEditorModal.tsx
@@ -3,8 +3,7 @@
 import dayjs from "dayjs";
 import { useEffect, useState } from "react";
 import { CharacterImportance, CharacterType, ChineseCharacter } from "./types";
-import { Button } from "../design-system/components/button";
-import { Card } from "../design-system/components/card";
+import { Body, Box, Button, Card, HStack, VStack } from "../design-system/components";
 import {
   Dialog,
   DialogContent,
@@ -136,12 +135,12 @@ export const CharacterEditorModal = ({
     >
       <DialogContent className="overflow-hidden border-white/10 bg-slate-900/95 p-0 text-slate-100">
         <Card className="relative w-full overflow-hidden border-0 bg-transparent text-slate-100 shadow-none">
-        <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_left,_rgba(34,211,238,0.22),_transparent_35%),radial-gradient(circle_at_bottom_right,_rgba(59,130,246,0.18),_transparent_40%)]" />
+        <Box className="absolute inset-0 bg-[radial-gradient(circle_at_top_left,_rgba(34,211,238,0.22),_transparent_35%),radial-gradient(circle_at_bottom_right,_rgba(59,130,246,0.18),_transparent_40%)]" />
         <div className="relative border-b border-white/10 px-8 py-7">
           <DialogHeader className="max-w-2xl pr-12">
-              <div className="mb-3 inline-flex rounded-full border border-cyan-400/20 bg-cyan-400/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.24em] text-cyan-200">
+              <Body className="mb-3 inline-flex rounded-full border border-cyan-400/20 bg-cyan-400/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.24em] text-cyan-200">
                 {mode === "create" ? "Add Character" : "Edit Current Card"}
-              </div>
+              </Body>
               <DialogTitle>
                 {mode === "create"
                   ? "Create a new study card"
@@ -154,7 +153,7 @@ export const CharacterEditorModal = ({
         </div>
 
         <form className="relative grid gap-6 px-8 py-7 lg:grid-cols-[1.25fr_0.9fr]" onSubmit={submit}>
-          <div className="space-y-5">
+          <VStack gap={20}>
             <label className="block text-sm font-medium text-slate-200">
               Character
               <input
@@ -200,9 +199,9 @@ export const CharacterEditorModal = ({
                 placeholder="Example sentence or mnemonic"
               />
             </label>
-          </div>
+          </VStack>
 
-          <div className="space-y-5">
+          <VStack gap={20}>
             <div className="grid gap-4 sm:grid-cols-2">
               <label className="block text-sm font-medium text-slate-200">
                 Type
@@ -254,15 +253,15 @@ export const CharacterEditorModal = ({
                 </select>
               </label>
             </div>
-          </div>
+          </VStack>
 
-          <div className="lg:col-span-2 flex items-center justify-between border-t border-white/10 pt-2">
-            <p className="text-sm text-slate-400">
+          <HStack className="lg:col-span-2 border-t border-white/10 pt-2" alignItems="center" justifyContent="space-between">
+            <Body as="p" className="text-sm text-slate-400">
               {mode === "create"
                 ? "New cards are created with today's dates and high importance by default."
                 : "Saving updates the current card instantly in the session."}
-            </p>
-            <div className="flex items-center gap-3">
+            </Body>
+            <HStack alignItems="center" gap={12}>
               <Button
                 type="button"
                 variant="ghost"
@@ -283,8 +282,8 @@ export const CharacterEditorModal = ({
                     ? "Create Character"
                     : "Update Character"}
               </Button>
-            </div>
-          </div>
+            </HStack>
+          </HStack>
         </form>
         </Card>
       </DialogContent>

--- a/frontend/src/components/CharacterPanel/CharacterPanel.tsx
+++ b/frontend/src/components/CharacterPanel/CharacterPanel.tsx
@@ -1,9 +1,15 @@
 import { Spinner } from "@radix-ui/themes";
 import { ArrowLeft, Pencil, Plus } from "lucide-react";
-import { ChineseCharacter } from "../types";
-import { Card } from "../../design-system/components/card";
-import { Button } from "../../design-system/components/button";
+import {
+  Body,
+  Box,
+  Button,
+  Card,
+  HStack,
+  VStack,
+} from "../../design-system/components";
 import { SessionPieChart } from "../SessionPieChart";
+import { ChineseCharacter } from "../types";
 import { ControlButtons } from "./ControlButtons";
 
 export const CharacterPanelView = ({
@@ -44,7 +50,11 @@ export const CharacterPanelView = ({
           Back
         </Button>
       )}
-      <div className="absolute top-4 right-4 z-20 flex items-center gap-2">
+      <HStack
+        className="absolute top-4 right-4 z-20"
+        alignItems="center"
+        gap={8}
+      >
         <Button
           variant="outline"
           size="sm"
@@ -64,32 +74,32 @@ export const CharacterPanelView = ({
           <Pencil className="mr-1 h-4 w-4" />
           Edit
         </Button>
-      </div>
+      </HStack>
       {isLoading ? (
-        <div className="flex flex-col items-center py-12">
+        <VStack className="py-12" alignItems="center">
           <Spinner className="animate-spin" />
-        </div>
+        </VStack>
       ) : (
-        <div className="flex flex-col items-center gap-2">
-          <h2 className="text-4xl font-bold tracking-tight">
+        <VStack alignItems="center" gap={8}>
+          <Body as="h2" className="text-4xl font-bold tracking-tight">
             {data?.translation}
-          </h2>
-          <div className="text-sm font-medium text-muted-foreground tracking-wide uppercase">
+          </Body>
+          <Body className="text-sm font-medium text-muted-foreground tracking-wide uppercase">
             {data?.type} / {data?.importance}
-          </div>
+          </Body>
           {showIdeogram && (
-            <div className="flex flex-col items-center mt-4 gap-3">
-              <div className="text-7xl font-bold bg-linear-to-br from-blue-400 to-indigo-400 bg-clip-text text-transparent">
+            <VStack className="mt-4" alignItems="center" gap={12}>
+              <Body as="h1" className="text-7xl font-bold bg-linear-to-br from-blue-400 to-indigo-400 bg-clip-text text-transparent">
                 {data?.character}
-              </div>
-              <div className="text-lg text-muted-foreground italic">
+              </Body>
+              <Body as="p" className="text-lg text-muted-foreground italic">
                 {data?.example}
-              </div>
-            </div>
+              </Body>
+            </VStack>
           )}
-        </div>
+        </VStack>
       )}
-      <div className="flex flex-col items-center space-y-4">
+      <VStack className="space-y-4" alignItems="center">
         <ControlButtons
           handleCheck={handleCheck}
           handleReveal={handleReveal}
@@ -97,13 +107,13 @@ export const CharacterPanelView = ({
           isLoading={isLoading}
           showIdeogram={showIdeogram}
         />
-        <div className="w-full">
+        <Box className="w-full">
           <SessionPieChart
             knownCount={knownCharacters.length}
             totalCount={totalCount}
           />
-        </div>
-      </div>
+        </Box>
+      </VStack>
     </Card>
   );
 };

--- a/frontend/src/components/CharacterPanel/ControlButtons.tsx
+++ b/frontend/src/components/CharacterPanel/ControlButtons.tsx
@@ -1,6 +1,9 @@
-import { Button } from "../../design-system/components/button";
-import { CheckIcon } from "../../design-system/components/CheckIcon";
-import { XIcon } from "../../design-system/components/XIcon";
+import {
+  Button,
+  CheckIcon,
+  HStack,
+  XIcon,
+} from "../../design-system/components";
 
 export const ControlButtons = ({
   handleCheck,
@@ -16,7 +19,7 @@ export const ControlButtons = ({
   showIdeogram: boolean;
 }) => {
   return (
-    <div className="flex justify-center gap-4">
+    <HStack justifyContent="center" gap={16}>
       <Button
         disabled={isLoading}
         onClick={handleCheck}
@@ -40,6 +43,6 @@ export const ControlButtons = ({
         <XIcon className="h-5 w-5" />
         Unknown
       </Button>
-    </div>
+    </HStack>
   );
 };

--- a/frontend/src/components/FiltersPanel/FiltersPanel.tsx
+++ b/frontend/src/components/FiltersPanel/FiltersPanel.tsx
@@ -1,3 +1,4 @@
+import { Body, VStack } from "../../design-system/components";
 import { CharacterImportance, CharacterType } from "../types";
 import { SelectCharacterImportance } from "./SelectCharacterImportance";
 import { SelectCharacterType } from "./SelectCharacterType";
@@ -10,22 +11,26 @@ export const FiltersPanel = ({
   setCharacterImportance: (importance: CharacterImportance | null) => void;
 }) => {
   return (
-    <div className="flex flex-col gap-4 w-48 shrink-0 self-start">
-      <h3 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+    <VStack className="w-48 shrink-0 self-start" gap={16}>
+      <Body as="h3" className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
         Filters
-      </h3>
-      <div className="flex flex-col gap-3">
-        <div className="flex flex-col gap-1.5">
-          <label className="text-xs text-muted-foreground">Type</label>
+      </Body>
+      <VStack gap={12}>
+        <VStack gap={6}>
+          <Body as="label" className="text-xs text-muted-foreground">
+            Type
+          </Body>
           <SelectCharacterType handleCharacterTypeChange={setCharacterType} />
-        </div>
-        <div className="flex flex-col gap-1.5">
-          <label className="text-xs text-muted-foreground">Importance</label>
+        </VStack>
+        <VStack gap={6}>
+          <Body as="label" className="text-xs text-muted-foreground">
+            Importance
+          </Body>
           <SelectCharacterImportance
             handleCharacterImportanceChange={setCharacterImportance}
           />
-        </div>
-      </div>
-    </div>
+        </VStack>
+      </VStack>
+    </VStack>
   );
 };

--- a/frontend/src/components/FlashcardsContainer.tsx
+++ b/frontend/src/components/FlashcardsContainer.tsx
@@ -19,6 +19,7 @@ import { useFetchChineseCharacter } from "./FlashcardsContainer.queries";
 import { useAppState } from "./hooks/useAppState";
 import { useKeyboardShortcuts } from "./hooks/useKeyboardShortcuts";
 import { useOnConfigurationChange } from "./hooks/useOnConfgiurationChange";
+import { Body, Box, Button, HStack, VStack } from "../design-system/components";
 import { SessionCharacterLists } from "./session-character-lists";
 import { ChineseCharacter } from "./types";
 
@@ -222,29 +223,30 @@ export function FlashcardsContainer({ onLogout, userEmail }: FlashcardsContainer
     isCreateCharacterLoading || isUpdateCharacterLoading;
 
   return (
-    <div className="dark flex flex-col items-center justify-center min-h-screen w-full bg-background text-card-foreground relative overflow-hidden">
-      <div className="absolute inset-0 bg-linear-to-br from-blue-950/30 via-background to-indigo-950/20 pointer-events-none" />
-      <div className="absolute top-4 left-4 z-10 flex items-center gap-3">
+    <VStack className="dark min-h-screen w-full bg-background text-card-foreground relative overflow-hidden" alignItems="center" justifyContent="center">
+      <Box className="absolute inset-0 bg-linear-to-br from-blue-950/30 via-background to-indigo-950/20 pointer-events-none" />
+      <HStack className="absolute top-4 left-4 z-10" alignItems="center" gap={12}>
         {onLogout ? (
-          <button
+          <Button
+            variant="ghost"
             className="glass rounded-xl px-4 py-2 text-sm font-medium text-muted-foreground transition hover:text-foreground"
             onClick={onLogout}
             type="button"
           >
             🚪 Sign out
-          </button>
+          </Button>
         ) : null}
-      </div>
-      <div className="absolute top-4 right-4 z-10 flex items-center gap-3">
+      </HStack>
+      <HStack className="absolute top-4 right-4 z-10" alignItems="center" gap={12}>
         {userEmail ? (
-          <span className="glass rounded-xl px-4 py-2 text-sm text-muted-foreground">{userEmail}</span>
+          <Body className="glass rounded-xl px-4 py-2 text-sm text-muted-foreground">{userEmail}</Body>
         ) : null}
-        <div className="glass rounded-xl px-4 py-2 text-sm font-medium text-muted-foreground shadow-lg">
-          <span className="text-foreground font-semibold">{uniqueSeenCount}</span>{" "}
+        <Body className="glass rounded-xl px-4 py-2 text-sm font-medium text-muted-foreground shadow-lg">
+          <Body className="text-foreground font-semibold">{uniqueSeenCount}</Body>{" "}
           seen
-        </div>
-      </div>
-      <div className="relative flex w-full max-w-7xl gap-6 px-6">
+        </Body>
+      </HStack>
+      <HStack className="relative w-full max-w-7xl px-6" gap={24}>
         <FiltersPanel
           setCharacterType={setCharacterType}
           setCharacterImportance={setCharacterImportance}
@@ -279,7 +281,7 @@ export function FlashcardsContainer({ onLogout, userEmail }: FlashcardsContainer
           unknownCharacters={unknownCharacters}
           onCharacterClick={startReview}
         />
-      </div>
+      </HStack>
       <CharacterEditorModal
         isOpen={Boolean(editorState)}
         mode={editorState?.mode ?? "create"}
@@ -292,6 +294,6 @@ export function FlashcardsContainer({ onLogout, userEmail }: FlashcardsContainer
         }}
         onSubmit={handleCharacterEditorSubmit}
       />
-    </div>
+    </VStack>
   );
 }

--- a/frontend/src/components/LoginPage.tsx
+++ b/frontend/src/components/LoginPage.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { FormEvent, useState } from "react";
+import { Body, Box, Button, HStack, VStack } from "../design-system/components";
 import { signInWithPassword, startGoogleOAuthLogin } from "../lib/supabaseClient";
 
 type LoginPageProps = {
@@ -35,17 +36,27 @@ export const LoginPage = ({ onLoggedIn }: LoginPageProps) => {
   };
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-background p-4">
-      <div className="absolute inset-0 bg-[linear-gradient(to_bottom_right,hsl(230_25%_7%),hsl(230_30%_12%))] pointer-events-none" />
-      <div className="relative w-full max-w-md rounded-2xl border border-white/10 bg-card p-6 shadow-xl shadow-cyan-950/20">
-        <h1 className="text-2xl font-semibold tracking-tight text-foreground">Sign in</h1>
-        <p className="mt-1 text-sm text-muted-foreground">Use your email/password or Google account.</p>
+    <VStack
+      className="min-h-screen bg-background p-4 relative"
+      alignItems="center"
+      justifyContent="center"
+    >
+      <Box className="absolute inset-0 bg-[linear-gradient(to_bottom_right,hsl(230_25%_7%),hsl(230_30%_12%))] pointer-events-none" />
+      <VStack className="relative w-full max-w-md rounded-2xl border border-white/10 bg-card p-6 shadow-xl shadow-cyan-950/20" gap={24}>
+        <VStack gap={4}>
+          <Body as="h1" className="text-2xl font-semibold tracking-tight text-foreground">
+            Sign in
+          </Body>
+          <Body as="p" className="text-sm text-muted-foreground">
+            Use your email/password or Google account.
+          </Body>
+        </VStack>
 
-        <form className="mt-6 space-y-4" onSubmit={onPasswordLogin}>
-          <div className="space-y-1">
-            <label className="text-sm font-medium text-foreground" htmlFor="email">
+        <VStack as="form" gap={16} onSubmit={onPasswordLogin}>
+          <VStack gap={4}>
+            <Body as="label" className="text-sm font-medium text-foreground" htmlFor="email">
               Email
-            </label>
+            </Body>
             <input
               id="email"
               className="w-full rounded-lg border border-white/10 bg-white/5 px-3 py-2 text-sm text-foreground outline-none placeholder:text-muted-foreground focus:border-cyan-400/50 focus:ring-2 focus:ring-cyan-400/20"
@@ -55,12 +66,12 @@ export const LoginPage = ({ onLoggedIn }: LoginPageProps) => {
               autoComplete="email"
               required
             />
-          </div>
+          </VStack>
 
-          <div className="space-y-1">
-            <label className="text-sm font-medium text-foreground" htmlFor="password">
+          <VStack gap={4}>
+            <Body as="label" className="text-sm font-medium text-foreground" htmlFor="password">
               Password
-            </label>
+            </Body>
             <input
               id="password"
               className="w-full rounded-lg border border-white/10 bg-white/5 px-3 py-2 text-sm text-foreground outline-none placeholder:text-muted-foreground focus:border-cyan-400/50 focus:ring-2 focus:ring-cyan-400/20"
@@ -70,34 +81,35 @@ export const LoginPage = ({ onLoggedIn }: LoginPageProps) => {
               autoComplete="current-password"
               required
             />
-          </div>
+          </VStack>
 
-          {errorMessage ? <p className="text-sm text-red-400">{errorMessage}</p> : null}
+          {errorMessage ? <Body as="p" className="text-sm text-red-400">{errorMessage}</Body> : null}
 
-          <button
+          <Button
             className="w-full rounded-xl bg-emerald-600 px-4 py-2.5 text-sm font-medium text-white shadow-lg shadow-emerald-900/30 transition hover:bg-emerald-500 disabled:cursor-not-allowed disabled:opacity-60"
             type="submit"
             disabled={isSubmitting}
           >
             {isSubmitting ? "Signing in..." : "Sign in with email"}
-          </button>
-        </form>
+          </Button>
+        </VStack>
 
-        <div className="my-4 flex items-center gap-3 text-xs text-muted-foreground">
-          <div className="h-px flex-1 bg-white/10" />
-          <span>OR</span>
-          <div className="h-px flex-1 bg-white/10" />
-        </div>
+        <HStack className="text-xs text-muted-foreground" alignItems="center" gap={12}>
+          <Box className="h-px flex-1 bg-white/10" />
+          <Body>OR</Body>
+          <Box className="h-px flex-1 bg-white/10" />
+        </HStack>
 
-        <button
+        <Button
+          variant="outline"
           className="w-full rounded-xl border border-white/10 bg-white/5 px-4 py-2.5 text-sm font-medium text-foreground transition hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-60"
           type="button"
           onClick={onGoogleLogin}
           disabled={isSubmitting}
         >
           Continue with Google
-        </button>
-      </div>
-    </div>
+        </Button>
+      </VStack>
+    </VStack>
   );
 };

--- a/frontend/src/components/session-character-lists.tsx
+++ b/frontend/src/components/session-character-lists.tsx
@@ -1,8 +1,14 @@
 "use client";
 
 import { toast } from "sonner";
+import {
+  Body,
+  Box,
+  Button,
+  HStack,
+  VStack,
+} from "../design-system/components";
 import { ChineseCharacter } from "./types";
-import { Button } from "../design-system/components/button";
 
 const copyCharactersToClipboard = async (characters: ChineseCharacter[]) => {
   const text = characters.map((c) => c.character).join("\n");
@@ -24,20 +30,19 @@ const CharacterList = ({
   const colorClasses =
     accentColor === "green" ? "text-emerald-400" : "text-red-400";
 
-  const dotColor =
-    accentColor === "green" ? "bg-emerald-400" : "bg-red-400";
+  const dotColor = accentColor === "green" ? "bg-emerald-400" : "bg-red-400";
 
   const isEmpty = characters.length === 0;
 
   return (
-    <div className="flex flex-col min-h-0 flex-1">
-      <div className="flex items-center justify-between mb-2">
-        <div className="flex items-center gap-2">
-          <div className={`w-2 h-2 rounded-full ${dotColor}`} />
-          <h3 className={`text-sm font-semibold uppercase tracking-wider whitespace-nowrap ${colorClasses}`}>
+    <VStack className="min-h-0 flex-1">
+      <HStack className="mb-2" justifyContent="space-between" alignItems="center">
+        <HStack alignItems="center" gap={8}>
+          <Box className={`w-2 h-2 rounded-full ${dotColor}`} />
+          <Body as="h3" className={`text-sm font-semibold uppercase tracking-wider whitespace-nowrap ${colorClasses}`}>
             {title} ({characters.length})
-          </h3>
-        </div>
+          </Body>
+        </HStack>
         {!isEmpty && (
           <Button
             variant="ghost"
@@ -48,25 +53,28 @@ const CharacterList = ({
             Copy
           </Button>
         )}
-      </div>
-      <div className="flex-1 overflow-y-auto rounded-lg glass p-2.5">
+      </HStack>
+      <Box className="flex-1 overflow-y-auto rounded-lg glass p-2.5">
         {isEmpty ? (
-          <p className="text-xs text-muted-foreground/60 italic">None yet</p>
+          <Body as="p" className="text-xs text-muted-foreground/60 italic">
+            None yet
+          </Body>
         ) : (
-          <ul className="space-y-0.5">
+          <VStack as="ul" className="space-y-0.5">
             {characters.map((character) => (
-              <li
+              <Body
+                as="li"
                 key={character.id}
                 className="text-base leading-relaxed text-foreground/80 cursor-pointer rounded px-1 hover:bg-white/10 transition-colors"
                 onClick={() => onCharacterClick(character)}
               >
                 {character.character}
-              </li>
+              </Body>
             ))}
-          </ul>
+          </VStack>
         )}
-      </div>
-    </div>
+      </Box>
+    </VStack>
   );
 };
 
@@ -80,7 +88,7 @@ export const SessionCharacterLists = ({
   onCharacterClick: (character: ChineseCharacter) => void;
 }) => {
   return (
-    <div className="w-96 shrink-0 flex gap-3 max-h-[80vh] self-start">
+    <HStack className="w-96 shrink-0 max-h-[80vh] self-start" gap={12}>
       <CharacterList
         title="Known"
         characters={knownCharacters}
@@ -93,6 +101,6 @@ export const SessionCharacterLists = ({
         accentColor="red"
         onCharacterClick={onCharacterClick}
       />
-    </div>
+    </HStack>
   );
 };

--- a/frontend/src/design-system/components/index.ts
+++ b/frontend/src/design-system/components/index.ts
@@ -30,3 +30,5 @@ export {
 } from "./select";
 export { CheckIcon } from "./CheckIcon";
 export { XIcon } from "./XIcon";
+
+export { Box, HStack, VStack, Body } from "./layout";

--- a/frontend/src/design-system/components/layout.tsx
+++ b/frontend/src/design-system/components/layout.tsx
@@ -1,0 +1,72 @@
+import { ComponentPropsWithoutRef, ElementType, CSSProperties } from "react";
+import { cn } from "../../lib/utils";
+
+type BoxProps<T extends ElementType = "div"> = {
+  as?: T;
+} & ComponentPropsWithoutRef<T>;
+
+export const Box = <T extends ElementType = "div">({
+  as,
+  className,
+  ...props
+}: BoxProps<T>) => {
+  const Component = as ?? "div";
+
+  return <Component className={cn(className)} {...props} />;
+};
+
+type StackProps<T extends ElementType = "div"> = BoxProps<T> & {
+  gap?: CSSProperties["gap"];
+  justifyContent?: CSSProperties["justifyContent"];
+  alignItems?: CSSProperties["alignItems"];
+};
+
+export const HStack = <T extends ElementType = "div">({
+  as,
+  className,
+  style,
+  gap,
+  justifyContent,
+  alignItems,
+  ...props
+}: StackProps<T>) => {
+  const Component = as ?? "div";
+
+  return (
+    <Component
+      className={cn("flex flex-row", className)}
+      style={{ ...style, gap, justifyContent, alignItems }}
+      {...props}
+    />
+  );
+};
+
+export const VStack = <T extends ElementType = "div">({
+  as,
+  className,
+  style,
+  gap,
+  justifyContent,
+  alignItems,
+  ...props
+}: StackProps<T>) => {
+  const Component = as ?? "div";
+
+  return (
+    <Component
+      className={cn("flex flex-col", className)}
+      style={{ ...style, gap, justifyContent, alignItems }}
+      {...props}
+    />
+  );
+};
+
+export const Body = <T extends ElementType = "span">({
+  as,
+  className,
+  ...props
+}: BoxProps<T>) => {
+  const Component = as ?? "span";
+
+  return <Component className={cn(className)} {...props} />;
+};


### PR DESCRIPTION
### Motivation
- Unify layout and typographic primitives across the app by introducing small, generic design-system components to reduce ad-hoc markup and simplify future refactors. 
- Provide `HStack`/`VStack` stacking primitives with `gap`, `justifyContent`, and `alignItems` support together with `Box` and `Body` wrappers to cover common layout/semantic needs. 
- Replace scattered native elements and inline layout with design-system pieces so components are easier to theme and maintain.

### Description
- Added `frontend/src/design-system/components/layout.tsx` which exports `Box`, `HStack`, `VStack`, and `Body` primitives that accept `as`, `className`, and style props (including `gap`, `justifyContent`, `alignItems`).
- Re-exported the new primitives from `frontend/src/design-system/components/index.ts` so they are available via the central design-system import surface.
- Migrated multiple UI surfaces to use the new primitives and the existing DS `Button`/`Card`/`Dialog` components, specifically updating `FlashcardsContainer`, `CharacterPanel`, `ControlButtons`, `FiltersPanel`, `SessionCharacterLists`, `LoginPage`, and parts of `CharacterEditorModal` to use `Box`/`HStack`/`VStack`/`Body` and replaced inline `div`/`span`/`button` usages where appropriate.
- Updated imports across affected files to pull DS primitives from `../design-system/components` and kept visual styles intact by preserving class names.

### Testing
- Ran type checking with `pnpm -C frontend type-check` which completed successfully. 
- Ran linter with `pnpm -C frontend lint` which completed successfully but left an existing React hooks `exhaustive-deps` warning in `useOnConfgiurationChange.ts`. 
- Ran unit tests with `pnpm -C frontend test` (Vitest) and all tests passed. 
- Started the dev server with `pnpm -C frontend dev` and verified the app compiled and served (note: Next logged a Google Fonts fetch warning and fell back to a local font), and a screenshot of the running UI was captured to validate the visual update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b57836505c832f9cb304b7726f44fb)