### PR TITLE
Add unit tests for character APIs and selection logic; add Vitest setup to stub network

### DIFF
--- a/frontend/src/app/api/_lib/domain/__tests__/selectRandomCharacter.test.ts
+++ b/frontend/src/app/api/_lib/domain/__tests__/selectRandomCharacter.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { selectRandomCharacter } from "../characterSelection";
+import { ChineseCharacter } from "../types";
+
+const characters: ChineseCharacter[] = [
+  {
+    id: "1",
+    character: "你",
+    translation: "you",
+    example: null,
+    addedAt: null,
+    type: "noun",
+    importance: "high",
+    lastSeenAt: null,
+    numberOfCorrectAnswers: 0,
+    levelOfConfidence: "low",
+  },
+  {
+    id: "2",
+    character: "好",
+    translation: "good",
+    example: null,
+    addedAt: null,
+    type: "adjective",
+    importance: "high",
+    lastSeenAt: null,
+    numberOfCorrectAnswers: 2,
+    levelOfConfidence: "high",
+  },
+];
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("selectRandomCharacter", () => {
+  it("returns the first character when random is 0", () => {
+    vi.spyOn(Math, "random").mockReturnValue(0);
+
+    const selected = selectRandomCharacter(characters);
+
+    expect(selected).toEqual(characters[0]);
+  });
+
+  it("returns the last character when random is close to 1", () => {
+    vi.spyOn(Math, "random").mockReturnValue(0.99999);
+
+    const selected = selectRandomCharacter(characters);
+
+    expect(selected).toEqual(characters[1]);
+  });
+});

--- a/frontend/src/app/api/character-known/__tests__/route.test.ts
+++ b/frontend/src/app/api/character-known/__tests__/route.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { POST } from "../route";
+import { setCharacterKnown } from "@/app/api/_lib/dependencies/supabase";
+
+vi.mock("@/app/api/_lib/auth", () => ({
+  assertAuthorizedEmail: vi.fn().mockResolvedValue(undefined),
+  toAuthErrorResponse: vi.fn().mockReturnValue(null),
+}));
+
+vi.mock("@/app/api/_lib/dependencies/supabase", () => ({
+  setCharacterKnown: vi.fn(),
+}));
+
+const setCharacterKnownMock = vi.mocked(setCharacterKnown);
+
+const createAuthedRequest = (url: string, body: unknown) =>
+  new Request(url, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      authorization: "Bearer test-token",
+      "x-api-key": "test-api-key",
+    },
+    body: JSON.stringify(body),
+  });
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("POST /api/character-known", () => {
+  it("returns 400 when id is missing", async () => {
+    const request = createAuthedRequest("http://localhost/api/character-known", {});
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: "Missing id" });
+    expect(setCharacterKnownMock).not.toHaveBeenCalled();
+  });
+
+  it("marks character as known when id is provided", async () => {
+    const request = createAuthedRequest("http://localhost/api/character-known", { id: "abc" });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ id: "abc" });
+    expect(setCharacterKnownMock).toHaveBeenCalledWith("abc");
+  });
+
+  it("returns 500 when update fails", async () => {
+    setCharacterKnownMock.mockRejectedValueOnce(new Error("db down"));
+
+    const request = createAuthedRequest("http://localhost/api/character-known", { id: "abc" });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual({ error: "Failed to update character" });
+  });
+});

--- a/frontend/src/app/api/character-known/route.ts
+++ b/frontend/src/app/api/character-known/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { assertAuthorizedEmail, toAuthErrorResponse } from "../_lib/auth";
-import { setCharacterKnown } from "../_lib/dependencies/supabase";
+import { setCharacterKnown } from "@/app/api/_lib/dependencies/supabase";
 
 export const runtime = "nodejs";
 

--- a/frontend/src/app/api/character-unknown/__tests__/route.test.ts
+++ b/frontend/src/app/api/character-unknown/__tests__/route.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { POST } from "../route";
+import { setCharacterUnknown } from "@/app/api/_lib/dependencies/supabase";
+
+vi.mock("@/app/api/_lib/auth", () => ({
+  assertAuthorizedEmail: vi.fn().mockResolvedValue(undefined),
+  toAuthErrorResponse: vi.fn().mockReturnValue(null),
+}));
+
+vi.mock("@/app/api/_lib/dependencies/supabase", () => ({
+  setCharacterUnknown: vi.fn(),
+}));
+
+const setCharacterUnknownMock = vi.mocked(setCharacterUnknown);
+
+const createAuthedRequest = (url: string, body: unknown) =>
+  new Request(url, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      authorization: "Bearer test-token",
+      "x-api-key": "test-api-key",
+    },
+    body: JSON.stringify(body),
+  });
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("POST /api/character-unknown", () => {
+  it("returns 400 when id is missing", async () => {
+    const request = createAuthedRequest("http://localhost/api/character-unknown", {});
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: "Missing id" });
+    expect(setCharacterUnknownMock).not.toHaveBeenCalled();
+  });
+
+  it("marks character as unknown when id is provided", async () => {
+    const request = createAuthedRequest("http://localhost/api/character-unknown", { id: "abc" });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ id: "abc" });
+    expect(setCharacterUnknownMock).toHaveBeenCalledWith("abc");
+  });
+
+  it("returns 500 when update fails", async () => {
+    setCharacterUnknownMock.mockRejectedValueOnce(new Error("db down"));
+
+    const request = createAuthedRequest("http://localhost/api/character-unknown", { id: "abc" });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual({ error: "Failed to update character" });
+  });
+});

--- a/frontend/src/app/api/character-unknown/route.ts
+++ b/frontend/src/app/api/character-unknown/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { assertAuthorizedEmail, toAuthErrorResponse } from "../_lib/auth";
-import { setCharacterUnknown } from "../_lib/dependencies/supabase";
+import { setCharacterUnknown } from "@/app/api/_lib/dependencies/supabase";
 
 export const runtime = "nodejs";
 

--- a/frontend/src/app/api/fetch-chinese-character/__tests__/route.test.ts
+++ b/frontend/src/app/api/fetch-chinese-character/__tests__/route.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { POST } from "../route";
+import type { ChineseCharacter } from "../../_lib/domain/types";
+import {
+  fetchRecentlyKnownCharacters,
+  fetchUnknownCharacters,
+} from "@/app/api/_lib/dependencies/supabase";
+
+vi.mock("@/app/api/_lib/auth", () => ({
+  assertAuthorizedEmail: vi.fn().mockResolvedValue(undefined),
+  toAuthErrorResponse: vi.fn().mockReturnValue(null),
+}));
+
+vi.mock("@/app/api/_lib/dependencies/supabase", () => ({
+  fetchUnknownCharacters: vi.fn(),
+  fetchRecentlyKnownCharacters: vi.fn(),
+}));
+
+const fetchUnknownCharactersMock = vi.mocked(fetchUnknownCharacters);
+const fetchRecentlyKnownCharactersMock = vi.mocked(fetchRecentlyKnownCharacters);
+
+const createCharacter = (
+  id: string,
+  levelOfConfidence: "high" | "low",
+  numberOfCorrectAnswers: number,
+  lastSeenAt: Date
+): ChineseCharacter => ({
+  id,
+  character: "字",
+  translation: "character",
+  example: null,
+  addedAt: null,
+  type: "noun",
+  importance: "high",
+  levelOfConfidence,
+  numberOfCorrectAnswers,
+  lastSeenAt,
+});
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2026-03-01T00:00:00.000Z"));
+  vi.spyOn(Math, "random").mockReturnValue(0);
+});
+
+const createAuthedRequest = (url: string, body: unknown) =>
+  new Request(url, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      authorization: "Bearer test-token",
+      "x-api-key": "test-api-key",
+    },
+    body: JSON.stringify(body),
+  });
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe("POST /api/fetch-chinese-character", () => {
+  it("returns one of the unknown characters when available", async () => {
+    const unknown = [createCharacter("unknown-1", "low", 0, new Date())];
+    fetchUnknownCharactersMock.mockResolvedValueOnce(unknown);
+
+    const request = createAuthedRequest("http://localhost/api/fetch-chinese-character", {
+      characterType: "noun",
+      characterImportance: "high",
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      ...unknown[0],
+      lastSeenAt: unknown[0].lastSeenAt?.toISOString() ?? null,
+    });
+    expect(fetchUnknownCharactersMock).toHaveBeenCalledWith(
+      { characterType: "noun", characterImportance: "high" },
+      50
+    );
+    expect(fetchRecentlyKnownCharactersMock).not.toHaveBeenCalled();
+  });
+
+  it("falls back to recently known characters and filters forgotten characters", async () => {
+    fetchUnknownCharactersMock.mockResolvedValueOnce([]);
+    const forgotten = createCharacter(
+      "known-1",
+      "high",
+      1,
+      new Date("2026-01-01T00:00:00.000Z")
+    );
+    const fresh = createCharacter(
+      "known-2",
+      "high",
+      5,
+      new Date("2026-02-28T00:00:00.000Z")
+    );
+
+    fetchRecentlyKnownCharactersMock.mockResolvedValueOnce([forgotten, fresh]);
+
+    const request = createAuthedRequest("http://localhost/api/fetch-chinese-character", {
+      characterType: null,
+      characterImportance: null,
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      ...forgotten,
+      lastSeenAt: forgotten.lastSeenAt?.toISOString() ?? null,
+    });
+    expect(fetchRecentlyKnownCharactersMock).toHaveBeenCalledWith(
+      { characterType: null, characterImportance: null },
+      50
+    );
+  });
+
+  it("returns 500 when data fetching fails", async () => {
+    fetchUnknownCharactersMock.mockRejectedValueOnce(new Error("db down"));
+
+    const request = createAuthedRequest("http://localhost/api/fetch-chinese-character", {
+      characterType: null,
+      characterImportance: null,
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual({ error: "Failed to fetch character" });
+  });
+});

--- a/frontend/src/app/api/fetch-chinese-character/route.ts
+++ b/frontend/src/app/api/fetch-chinese-character/route.ts
@@ -3,7 +3,7 @@ import { assertAuthorizedEmail, toAuthErrorResponse } from "../_lib/auth";
 import {
   fetchRecentlyKnownCharacters,
   fetchUnknownCharacters,
-} from "../_lib/dependencies/supabase";
+} from "@/app/api/_lib/dependencies/supabase";
 import {
   characterNeedsRefresh,
   selectRandomCharacter,

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,5 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    },
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
   test: {
     environment: "node",
     globals: true,
+    setupFiles: ["./vitest.setup.ts"],
   },
   resolve: {
     alias: {

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -1,0 +1,16 @@
+import { afterEach, vi } from "vitest";
+
+// Prevent accidental outbound network calls in unit/integration tests.
+// Tests that intentionally need fetch should mock it explicitly.
+vi.stubGlobal(
+  "fetch",
+  vi.fn(async () => {
+    throw new Error(
+      "Unexpected network call in test. Mock auth/dependencies instead of calling real services."
+    );
+  })
+);
+
+afterEach(() => {
+  vi.clearAllMocks();
+});


### PR DESCRIPTION
### Motivation
- Add unit tests to validate character selection and the `/api/*` endpoints' behavior and error handling.
- Prevent accidental outbound network calls during tests by stubbing global `fetch` in a centralized setup.
- Make tests deterministic for randomness and time-dependent logic by mocking `Math.random` and using fake timers.

### Description
- Added unit tests for domain selection `selectRandomCharacter` (`frontend/src/app/api/_lib/domain/__tests__/selectRandomCharacter.test.ts`) and API routes `fetch-chinese-character`, `character-known`, and `character-unknown` under `frontend/src/app/api/*/__tests__`, with Supabase dependencies mocked.
- Introduced `vitest.setup.ts` which stubs global `fetch` to throw on unexpected network calls and clears mocks after each test, and updated `vitest.config.ts` to include the setup file via `setupFiles`.
- Tests exercise happy paths and error paths, mock `Math.random` and use `vi.useFakeTimers` where appropriate, and assert JSON responses and calls to mocked dependency functions.

### Testing
- Ran the test suite with `vitest` including the new tests and they completed successfully with all new tests passing.
- Verified the route tests cover missing parameter validation and simulated dependency failures, and the domain test verifies deterministic selection when `Math.random` is mocked.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af376f4378832fbd88a59fe8b1e5ca)