### PR TITLE
Prevent duplicate next card progression and deduplicate known/unknown lists

### DIFF
--- a/frontend/src/components/hooks/useAppState.ts
+++ b/frontend/src/components/hooks/useAppState.ts
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { CharacterType, CharacterImportance, ChineseCharacter } from "../types";
 import { compact, uniq } from "lodash-es";
 import { useReviewState } from "./useReviewState";
+import { resolveNextCharacter, upsertCharacterById } from "../sessionState";
 
 export const useAppState = () => {
   const [showIdeogram, setShowIdeogram] = useState(false);
@@ -30,8 +31,12 @@ export const useAppState = () => {
     currentCharacter: ChineseCharacter | null;
     nextCharacter: ChineseCharacter | null;
   }) => {
+    const resolvedNextCharacter = resolveNextCharacter({
+      currentCharacter,
+      nextCharacter,
+    });
     const newState = {
-      currentCharacter: nextCharacter,
+      currentCharacter: resolvedNextCharacter,
       nextCharacter: null,
     };
     setCurrentCharacter(newState.currentCharacter);
@@ -45,11 +50,11 @@ export const useAppState = () => {
   };
 
   const addKnownCharacter = (character: ChineseCharacter) => {
-    setKnownCharacters((prev) => [...prev, character]);
+    setKnownCharacters((prev) => upsertCharacterById(prev, character));
   };
 
   const addUnknownCharacter = (character: ChineseCharacter) => {
-    setUnknownCharacters((prev) => [...prev, character]);
+    setUnknownCharacters((prev) => upsertCharacterById(prev, character));
   };
 
   const { isReviewing, startReview, exitReview, recategorizeReviewedCharacter } =

--- a/frontend/src/components/hooks/useReviewState.ts
+++ b/frontend/src/components/hooks/useReviewState.ts
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { ChineseCharacter } from "../types";
+import { upsertCharacterById } from "../sessionState";
 
 type ReviewSnapshot = {
   previousCharacter: ChineseCharacter;
@@ -52,18 +53,14 @@ export const useReviewState = ({
     if (!currentCharacter || !reviewSnapshot) return currentCharacter;
     const characterId = currentCharacter.id;
     if (targetList === "known") {
-      setKnownCharacters((prev) => [
-        ...prev.filter((c) => c.id !== characterId),
-        currentCharacter,
-      ]);
+      setKnownCharacters((prev) => upsertCharacterById(prev, currentCharacter));
       setUnknownCharacters((prev) =>
         prev.filter((c) => c.id !== characterId)
       );
     } else {
-      setUnknownCharacters((prev) => [
-        ...prev.filter((c) => c.id !== characterId),
-        currentCharacter,
-      ]);
+      setUnknownCharacters((prev) =>
+        upsertCharacterById(prev, currentCharacter)
+      );
       setKnownCharacters((prev) =>
         prev.filter((c) => c.id !== characterId)
       );

--- a/frontend/src/components/sessionState.test.ts
+++ b/frontend/src/components/sessionState.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { resolveNextCharacter, upsertCharacterById } from "./sessionState";
+import { ChineseCharacter } from "./types";
+
+const createCharacter = (id: string, character: string): ChineseCharacter => ({
+  id,
+  character,
+  translation: `translation-${id}`,
+  example: `example-${id}`,
+  addedAt: null,
+  type: "noun",
+  importance: "high",
+  levelOfConfidence: "low",
+  numberOfCorrectAnswers: 0,
+  lastSeenAt: null,
+});
+
+describe("resolveNextCharacter", () => {
+  it("returns null when prefetched character matches current character", () => {
+    const currentCharacter = createCharacter("1", "你");
+
+    const resolved = resolveNextCharacter({
+      currentCharacter,
+      nextCharacter: currentCharacter,
+    });
+
+    expect(resolved).toBeNull();
+  });
+
+  it("returns the prefetched character when it is different", () => {
+    const resolved = resolveNextCharacter({
+      currentCharacter: createCharacter("1", "你"),
+      nextCharacter: createCharacter("2", "好"),
+    });
+
+    expect(resolved?.id).toBe("2");
+  });
+});
+
+describe("upsertCharacterById", () => {
+  it("does not duplicate a character that already exists", () => {
+    const existing = createCharacter("1", "你");
+    const updated = {
+      ...existing,
+      translation: "you",
+    };
+
+    const result = upsertCharacterById([existing], updated);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.translation).toBe("you");
+  });
+});

--- a/frontend/src/components/sessionState.ts
+++ b/frontend/src/components/sessionState.ts
@@ -1,0 +1,22 @@
+import { ChineseCharacter } from "./types";
+
+export const upsertCharacterById = (
+  characters: ChineseCharacter[],
+  character: ChineseCharacter
+) => {
+  return [...characters.filter((item) => item.id !== character.id), character];
+};
+
+export const resolveNextCharacter = ({
+  currentCharacter,
+  nextCharacter,
+}: {
+  currentCharacter: ChineseCharacter | null;
+  nextCharacter: ChineseCharacter | null;
+}) => {
+  if (!nextCharacter) return null;
+  if (currentCharacter && nextCharacter.id === currentCharacter.id) {
+    return null;
+  }
+  return nextCharacter;
+};


### PR DESCRIPTION
### Motivation
- Intermittent UI bug where a prefetched card identical to the current one caused the last card to appear as "full green" and repeat, indicating incorrect session progression.
- Known/unknown lists were appending characters and could duplicate entries instead of updating them by id.

### Description
- Added `frontend/src/components/sessionState.ts` with `resolveNextCharacter` to ignore a prefetched card when its `id` matches the current card, and `upsertCharacterById` to replace or append characters by id.
- Updated `useAppState` to use `resolveNextCharacter` in `shiftForward` so the session no longer advances to a duplicate prefetched card, and changed `addKnownCharacter` / `addUnknownCharacter` to use `upsertCharacterById` for deduplication.
- Updated `useReviewState` to reuse `upsertCharacterById` when recategorizing reviewed characters so review-mode moves/update entries without creating duplicates.
- Added unit tests in `frontend/src/components/sessionState.test.ts` covering `resolveNextCharacter` behavior (duplicate vs different prefetched card) and `upsertCharacterById` deduplication.

### Testing
- Ran `pnpm --dir frontend test`, which completed successfully and reported all tests passing.
- Test run summary: 2 test files, 7 tests passed (both the existing `characterNeedsRefresh` tests and the new `sessionState.test.ts`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b580240120832fb1dfdc5fd5022ef1)