### PR TITLE
Add Dependabot configuration for npm and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
### Motivation
- Add Dependabot configuration to keep dependencies and workflow actions up-to-date automatically.

### Description
- Create ` .github/dependabot.yml` with weekly updates for `npm` at `/` and `/frontend` and for `github-actions`, each with `open-pull-requests-limit: 10`.

### Testing
- No automated tests were executed for this change; the change only adds configuration and will be exercised by Dependabot and the repository CI on future updates.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b59afe7ba0832fa3fc9027c2ef736d)