### PR TITLE
Add Cmd/Ctrl+F search modal shortcut and pinyin-friendly filtering

### DIFF
--- a/frontend/src/components/CharacterSearchModal.tsx
+++ b/frontend/src/components/CharacterSearchModal.tsx
@@ -106,6 +106,14 @@ type ResultsSummaryParams = {
   totalCount: number;
 };
 
+
+const normalizeForSearch = (value: string) =>
+  value
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/\s+/g, "")
+    .toLowerCase();
+
 const getResultsSummary = ({
   query,
   filteredCount,
@@ -148,10 +156,12 @@ export const CharacterSearchModal = ({
 
   const filtered = useMemo(() => {
     const allCharacters = data ?? [];
-    const normalizedQuery = query.trim().toLowerCase();
-    if (!normalizedQuery) {
+    const trimmedQuery = query.trim();
+    if (!trimmedQuery) {
       return allCharacters;
     }
+
+    const normalizedQuery = normalizeForSearch(trimmedQuery);
 
     return allCharacters.filter((character) =>
       [
@@ -161,8 +171,14 @@ export const CharacterSearchModal = ({
         character.type,
         character.importance,
       ]
-        .filter(Boolean)
-        .some((value) => value?.toLowerCase().includes(normalizedQuery))
+        .filter((value): value is string => Boolean(value))
+        .some((value) => {
+          const lowerValue = value.toLowerCase();
+          return (
+            lowerValue.includes(trimmedQuery.toLowerCase()) ||
+            normalizeForSearch(value).includes(normalizedQuery)
+          );
+        })
     );
   }, [data, query]);
 
@@ -213,7 +229,7 @@ export const CharacterSearchModal = ({
             No characters match this search yet.
           </Body>
           <Body className="max-w-md text-sm text-slate-400">
-            Try a character, translation, example, type, or importance keyword.
+            Try a character, pinyin, translation, example, type, or importance keyword.
           </Body>
         </VStack>
       );
@@ -292,7 +308,7 @@ export const CharacterSearchModal = ({
               </Body>
               <DialogTitle>Find and edit any character</DialogTitle>
               <DialogDescription className="mt-2">
-                Search by character, translation, type, example, or importance and
+                Search by character, pinyin, translation, type, example, or importance and
                 jump directly into the editor.
               </DialogDescription>
             </DialogHeader>
@@ -317,7 +333,7 @@ export const CharacterSearchModal = ({
               <input
                 value={query}
                 onChange={(event) => setQuery(event.target.value)}
-                placeholder="Search character, translation, example, type, or importance"
+                placeholder="Search character, pinyin, translation, example, type, or importance"
                 className="w-full rounded-2xl border border-white/10 bg-slate-950/70 py-3.5 pl-11 pr-4 text-sm text-slate-100 outline-hidden transition placeholder:text-slate-500 focus:border-cyan-400/70 focus:ring-2 focus:ring-cyan-400/20"
               />
             </label>

--- a/frontend/src/components/FlashcardsContainer.tsx
+++ b/frontend/src/components/FlashcardsContainer.tsx
@@ -20,6 +20,7 @@ import {
 import { useFetchChineseCharacter } from "./FlashcardsContainer.queries";
 import { useAppState } from "./hooks/useAppState";
 import { useKeyboardShortcuts } from "./hooks/useKeyboardShortcuts";
+import { useSearchTableShortcut } from "./hooks/useSearchTableShortcut";
 import { useOnConfigurationChange } from "./hooks/useOnConfgiurationChange";
 import { Body, Box, Button, HStack, VStack } from "../design-system/components";
 import { SessionCharacterLists } from "./session-character-lists";
@@ -220,6 +221,11 @@ export function FlashcardsContainer({ onLogout, userEmail }: FlashcardsContainer
     handleUnknown,
     isReviewing,
     onExitReview: exitReview,
+    isDisabled: Boolean(editorState),
+  });
+
+  useSearchTableShortcut({
+    onOpenSearch: () => setIsSearchOpen(true),
     isDisabled: Boolean(editorState),
   });
 

--- a/frontend/src/components/hooks/useSearchTableShortcut.ts
+++ b/frontend/src/components/hooks/useSearchTableShortcut.ts
@@ -1,0 +1,36 @@
+import { useEffect } from "react";
+
+const isTypingContext = (target: EventTarget | null) => {
+  const element = target as HTMLElement | null;
+  return (
+    element?.tagName === "INPUT" ||
+    element?.tagName === "TEXTAREA" ||
+    element?.tagName === "SELECT" ||
+    element?.isContentEditable
+  );
+};
+
+export const useSearchTableShortcut = ({
+  onOpenSearch,
+  isDisabled = false,
+}: {
+  onOpenSearch: () => void;
+  isDisabled?: boolean;
+}) => {
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const isFindShortcut = (event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "f";
+      if (!isFindShortcut || isDisabled || isTypingContext(event.target)) {
+        return;
+      }
+
+      event.preventDefault();
+      onOpenSearch();
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [isDisabled, onOpenSearch]);
+};


### PR DESCRIPTION
### Motivation
- Provide a dedicated, isolated shortcut to open the character search modal so users can quickly open it with `Cmd/Ctrl+F` without interfering with typing contexts. 
- Allow pinyin queries to match stored text regardless of tone marks or whitespace so searches for pronunciations work whether tone marks are present or not.

### Description
- Add a new hook `useSearchTableShortcut` at `frontend/src/components/hooks/useSearchTableShortcut.ts` that captures `Cmd/Ctrl+F`, ignores typing contexts, and calls a provided `onOpenSearch` callback. 
- Wire the new `useSearchTableShortcut` into `FlashcardsContainer` (`frontend/src/components/FlashcardsContainer.tsx`) to open the `CharacterSearchModal` via the shortcut and respect the editor-disabled state. 
- Implement accent- and whitespace-insensitive normalization via `normalizeForSearch` and update the filtering logic in `CharacterSearchModal` (`frontend/src/components/CharacterSearchModal.tsx`) so pinyin with or without tone marks will match. 
- Update modal copy and placeholder to explicitly mention pinyin support in the UI text.

### Testing
- Ran linting with `pnpm -C frontend exec eslint src/components/FlashcardsContainer.tsx src/components/CharacterSearchModal.tsx src/components/hooks/useSearchTableShortcut.ts` and it passed. 
- Ran type checking with `pnpm -C frontend exec tsc --noEmit` and it passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb156f80b0832fb266d8cc33b4eceb)