### PR TITLE
Randomize character fetch window while preserving filters

### DIFF
--- a/frontend/src/app/api/_lib/dependencies/supabase.ts
+++ b/frontend/src/app/api/_lib/dependencies/supabase.ts
@@ -131,6 +131,51 @@ const queryCharacters = async (params: URLSearchParams) => {
   return readResponse<CharacterRow[]>(response);
 };
 
+const countCharacters = async (params: URLSearchParams) => {
+  const countParams = new URLSearchParams(params);
+  countParams.set("select", "id");
+  countParams.delete("limit");
+  countParams.delete("offset");
+  countParams.delete("order");
+
+  const response = await fetch(buildRestUrl(TABLE_NAME, countParams), {
+    method: "GET",
+    headers: buildHeaders({
+      prefer: "count=exact",
+    }),
+  });
+
+  if (!response.ok) {
+    const message = await response.text();
+    throw new Error(`Supabase count request failed: ${response.status} ${message}`);
+  }
+
+  const contentRange = response.headers.get("content-range");
+  if (!contentRange) {
+    return 0;
+  }
+
+  const totalCount = Number(contentRange.split("/")[1]);
+  return Number.isFinite(totalCount) ? totalCount : 0;
+};
+
+const withRandomOffset = (
+  params: URLSearchParams,
+  totalMatchingCharacters: number,
+  limit: number
+) => {
+  if (totalMatchingCharacters <= limit) {
+    return params;
+  }
+
+  const maxOffset = totalMatchingCharacters - limit;
+  const offset = Math.floor(Math.random() * (maxOffset + 1));
+  const nextParams = new URLSearchParams(params);
+  nextParams.set("offset", String(offset));
+
+  return nextParams;
+};
+
 const upsertBodyFromInput = (
   input: CreateCharacterInput | UpdateCharacterInput
 ) => {
@@ -273,7 +318,9 @@ export const fetchUnknownCharacters = async (
     params.set("importance", `eq.${filters.characterImportance}`);
   }
 
-  const rows = await queryCharacters(params);
+  const totalMatchingCharacters = await countCharacters(params);
+  const randomizedParams = withRandomOffset(params, totalMatchingCharacters, limit);
+  const rows = await queryCharacters(randomizedParams);
   return rows.map(mapRowToChineseCharacter);
 };
 
@@ -297,7 +344,9 @@ export const fetchRecentlyKnownCharacters = async (
     params.set("importance", `eq.${filters.characterImportance}`);
   }
 
-  const rows = await queryCharacters(params);
+  const totalMatchingCharacters = await countCharacters(params);
+  const randomizedParams = withRandomOffset(params, totalMatchingCharacters, limit);
+  const rows = await queryCharacters(randomizedParams);
   return rows.map(mapRowToChineseCharacter);
 };
 


### PR DESCRIPTION
### Motivation
- Prevent repeatedly sampling the same leading slice of matching characters while keeping existing filter and ordering semantics.

### Description
- Add `countCharacters` which performs a lightweight PostgREST count using `Prefer: count=exact` and reads the `content-range` header to determine total matching rows.
- Add `withRandomOffset` to compute and apply a random `offset` when the total matching rows exceed the requested `limit`.
- Apply the random-offset logic to `fetchUnknownCharacters` and `fetchRecentlyKnownCharacters` so the same filters and ordering are preserved but a different candidate window is fetched.
- Preserve original behavior when total matching rows are less than or equal to `limit` (no offset applied).

### Testing
- Ran `pnpm --filter frontend run test` and all tests passed (`6` test files, `18` tests total).
- Ran `pnpm --filter frontend run type-check` and TypeScript type-check succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd6b94c2b8832f8455f28f62cac44e)