### PR TITLE
chore: enforce 3-day minimum pnpm release age

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
+  "pnpm": {
+    "minimumReleaseAge": 4320
+  },
   "devDependencies": {
     "@eslint/js": "^9.39.4",
     "eslint": "^9",


### PR DESCRIPTION
### Motivation
- Add a root `pnpm` configuration to avoid installing packages published less than 3 days ago by enforcing a minimum release age.

### Description
- Added a `pnpm` block to `package.json` with `minimumReleaseAge` set to `4320` (minutes) to enforce a 3-day delay.

### Testing
- Ran `node -e "JSON.parse(require('fs').readFileSync('package.json','utf8')); console.log('ok')"` which printed `ok`, indicating the updated `package.json` is valid JSON.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da0c2dc3fc832fb7c76acd92ef508a)