### PR TITLE
ci: add critical pnpm audit to lint job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
+      - name: Audit dependencies (critical)
+        run: pnpm audit --audit-level=critical
+
       - name: Type check
         run: pnpm --filter frontend run type-check
 


### PR DESCRIPTION
### Motivation
- Fail CI early on known-critical npm vulnerabilities by running `pnpm audit --audit-level=critical` in the `lint` job after dependencies are installed.

### Description
- Add an `Audit dependencies (critical)` step to `.github/workflows/ci.yml` in the `lint` job that runs `pnpm audit --audit-level=critical` before type-check and lint.

### Testing
- Ran `git diff --check` after the change which returned no issues and the file was committed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da3b58062c832f96824fd2a48185b0)