### PR TITLE
CI: pin pnpm, enforce frozen lockfile, and add critical dependency audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v5
         with:
-          version: latest
+          version: 10.13.1
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -26,7 +26,10 @@ jobs:
           cache: "pnpm"
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
+
+      - name: Audit dependencies (critical)
+        run: pnpm audit --audit-level=critical
 
       - name: Type check
         run: pnpm --filter frontend run type-check
@@ -44,7 +47,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v5
         with:
-          version: latest
+          version: 10.13.1
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -53,7 +56,7 @@ jobs:
           cache: "pnpm"
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Run unit tests
         run: pnpm --filter frontend run test


### PR DESCRIPTION
### Motivation
- Harden the CI pipeline by pinning the `pnpm` runner, ensuring lockfile consistency, and surfacing critical dependency vulnerabilities early.

### Description
- Pin `pnpm` to `10.13.1`, replace `pnpm install` with `pnpm install --frozen-lockfile` in both `lint` and `test` jobs, and add a `pnpm audit --audit-level=critical` step to the `lint` job.

### Testing
- No automated tests were executed as part of this change; the CI workflow is configured to run `Type check`, `Lint`, and `Unit tests` on push and pull requests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da3b58062c832f96824fd2a48185b0)